### PR TITLE
Elasticsearch-Mapping und Aggregationen für Umweltmanagement Verbrauchsdaten

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(Get-ChildItem -Path \"D:\\\\Entwicklungsprojekte\\\\Formular-System\" -Recurse -Directory)",
+      "Bash(Select-Object FullName)",
+      "Bash(xargs ls -lh)",
+      "Bash(xargs cat)"
+    ]
+  }
+}

--- a/elasticsearch/verbrauchsdaten_aggregations.json
+++ b/elasticsearch/verbrauchsdaten_aggregations.json
@@ -1,0 +1,177 @@
+{
+  "_comment_konzept": [
+    "Jedes Dokument enthält 'verbrauch_pro_tag' und 'co2_pro_tag_kg' als vorberechnete Tageswerte.",
+    "Damit lässt sich über beliebige Zeiträume aggregieren: Man summiert die Tageswerte",
+    "aller Dokumente, deren Abrechnungszeitraum (periode_von–periode_bis) in das Abfrageintervall fällt.",
+    "",
+    "Für exakte Tagesverteilung in Kibana: Dokument beim Indexieren in Tagesscheiben aufsplitten",
+    "(ein Dokument pro Tag, Wert = verbrauch_pro_tag). Dann funktionieren date_histogram-Aggregationen",
+    "direkt ohne Scripting. Alternativ: Scripted Aggregation (s. Beispiel 4 unten)."
+  ],
+
+  "beispiel_1_index_erstellen": {
+    "_comment": "Index anlegen mit dem Mapping aus verbrauchsdaten_mapping.json",
+    "method": "PUT",
+    "path": "/verbrauchsdaten",
+    "body": "{ ...Inhalt von verbrauchsdaten_mapping.json... }"
+  },
+
+  "beispiel_2_jahresverbrauch_nach_ressource": {
+    "_comment": "Jahresverbrauch 2025 gruppiert nach Ressource und Standort",
+    "method": "POST",
+    "path": "/verbrauchsdaten/_search",
+    "body": {
+      "size": 0,
+      "query": {
+        "range": {
+          "periode_von": {
+            "gte": "2025-01-01",
+            "lte": "2025-12-31"
+          }
+        }
+      },
+      "aggs": {
+        "nach_ressource": {
+          "terms": { "field": "ressource", "size": 20 },
+          "aggs": {
+            "nach_standort": {
+              "terms": { "field": "standort", "size": 20 },
+              "aggs": {
+                "verbrauch_summe": {
+                  "sum": { "field": "verbrauch_effektiv" }
+                },
+                "co2_summe_kg": {
+                  "sum": { "field": "co2_gesamt_kg" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "beispiel_3_monatlicher_verlauf": {
+    "_comment": [
+      "Monatlicher Verbrauch über ein Jahr – date_histogram auf periode_von.",
+      "Liefert korrekte Werte wenn pro Monat eine Abrechnung vorliegt.",
+      "Bei quartalsweisen Abrechnungen: verbrauch_pro_tag * 30.44 aus den Dokumenten nutzen."
+    ],
+    "method": "POST",
+    "path": "/verbrauchsdaten/_search",
+    "body": {
+      "size": 0,
+      "query": {
+        "bool": {
+          "filter": [
+            { "term": { "ressource": "Strom" } },
+            { "range": { "periode_von": { "gte": "2025-01-01", "lte": "2025-12-31" } } }
+          ]
+        }
+      },
+      "aggs": {
+        "nach_monat": {
+          "date_histogram": {
+            "field": "periode_von",
+            "calendar_interval": "month",
+            "format": "yyyy-MM"
+          },
+          "aggs": {
+            "verbrauch_gesamt": { "sum": { "field": "verbrauch_effektiv" } },
+            "co2_gesamt":       { "sum": { "field": "co2_gesamt_kg" } }
+          }
+        }
+      }
+    }
+  },
+
+  "beispiel_4_freies_intervall_mit_tageswerten": {
+    "_comment": [
+      "Freies Intervall: beliebige Zeitspanne abfragen, Verbrauch aus Tageswerten hochrechnen.",
+      "Strategie: Dokumente abrufen, deren Periode sich mit dem Abfrageintervall überschneidet,",
+      "dann verbrauch_pro_tag * (Überschneidungstage) summieren.",
+      "",
+      "Einfachste Näherung für Kibana ohne Scripting: Abfrage auf periode_von im Zielfenster",
+      "und Summe der verbrauch_pro_tag * periode_tage (= verbrauch_effektiv).",
+      "",
+      "Für korrekte Tagesverteilung wird empfohlen, beim Indexieren ein Dokument pro Tag",
+      "zu erstellen (Logstash split filter oder Custom Indexer)."
+    ],
+    "method": "POST",
+    "path": "/verbrauchsdaten/_search",
+    "body": {
+      "size": 0,
+      "query": {
+        "bool": {
+          "filter": [
+            { "range": { "periode_von": { "gte": "2025-03-01" } } },
+            { "range": { "periode_bis": { "lte": "2025-09-30" } } }
+          ]
+        }
+      },
+      "aggs": {
+        "nach_ressource": {
+          "terms": { "field": "ressource", "size": 10 },
+          "aggs": {
+            "verbrauch_summe": { "sum": { "field": "verbrauch_effektiv" } },
+            "tage_summe":      { "sum": { "field": "periode_tage" } },
+            "co2_summe_kg":    { "sum": { "field": "co2_gesamt_kg" } }
+          }
+        }
+      }
+    }
+  },
+
+  "beispiel_5_co2_vergleich_strom_nach_co2_faktor": {
+    "_comment": [
+      "Vergleich CO2-Intensität Strom nach Anbieterwechsel.",
+      "Gruppiert nach co2_faktor_kg_pro_einheit um verschiedene Tarifjahre zu unterscheiden."
+    ],
+    "method": "POST",
+    "path": "/verbrauchsdaten/_search",
+    "body": {
+      "size": 0,
+      "query": {
+        "term": { "ressource": "Strom" }
+      },
+      "aggs": {
+        "nach_co2_faktor": {
+          "terms": { "field": "co2_faktor_kg_pro_einheit", "size": 20 },
+          "aggs": {
+            "verbrauch_kwh": { "sum": { "field": "verbrauch_effektiv" } },
+            "co2_kg":        { "sum": { "field": "co2_gesamt_kg" } },
+            "zeitraum_von":  { "min": { "field": "periode_von" } },
+            "zeitraum_bis":  { "max": { "field": "periode_bis" } }
+          }
+        }
+      }
+    }
+  },
+
+  "beispiel_6_logstash_pipeline_tagesscheiben": {
+    "_comment": [
+      "Optionaler Ansatz: Logstash-Pipeline, die jede Einmeldung in N Tagesscheiben aufteilt.",
+      "Dann funktionieren date_histogram-Aggregationen in Kibana direkt über @timestamp.",
+      "Jede Tagesscheibe bekommt: verbrauch = verbrauch_pro_tag, co2_kg = co2_pro_tag_kg."
+    ],
+    "logstash_filter_snippet": [
+      "filter {",
+      "  ruby {",
+      "    code => '",
+      "      start = Date.parse(event.get(\"periode_von\"))",
+      "      stop  = Date.parse(event.get(\"periode_bis\"))",
+      "      events = []",
+      "      (start..stop).each do |day|",
+      "        e = event.clone",
+      "        e.set(\"@timestamp\", day.to_time)",
+      "        e.set(\"verbrauch\", event.get(\"verbrauch_pro_tag\"))",
+      "        e.set(\"co2_kg\",    event.get(\"co2_pro_tag_kg\"))",
+      "        events << e",
+      "      end",
+      "      return events",
+      "    '",
+      "  }",
+      "}"
+    ]
+  }
+}

--- a/elasticsearch/verbrauchsdaten_mapping.json
+++ b/elasticsearch/verbrauchsdaten_mapping.json
@@ -1,0 +1,132 @@
+{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 1,
+    "index": {
+      "lifecycle": {
+        "name": "verbrauchsdaten-policy"
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+
+      "@timestamp": {
+        "type": "date",
+        "doc_values": true
+      },
+
+      "erfasst_am": {
+        "type": "date",
+        "doc_values": true
+      },
+
+      "periode_von": {
+        "type": "date",
+        "doc_values": true
+      },
+
+      "periode_bis": {
+        "type": "date",
+        "doc_values": true
+      },
+
+      "periode_tage": {
+        "type": "integer"
+      },
+
+      "standort": {
+        "type": "keyword"
+      },
+
+      "standort_bezeichnung": {
+        "type": "keyword"
+      },
+
+      "ressource": {
+        "type": "keyword"
+      },
+
+      "lieferant": {
+        "type": "keyword"
+      },
+
+      "einheit": {
+        "type": "keyword"
+      },
+
+      "zaehler_id": {
+        "type": "keyword"
+      },
+
+      "zaehlwerk": {
+        "type": "keyword"
+      },
+
+      "wandlerfaktor": {
+        "type": "double"
+      },
+
+      "verbrauch_roh": {
+        "type": "double",
+        "doc_values": true
+      },
+
+      "verbrauch_effektiv": {
+        "type": "double",
+        "doc_values": true
+      },
+
+      "verbrauch_pro_tag": {
+        "type": "double",
+        "doc_values": true
+      },
+
+      "verbrauch_pro_woche": {
+        "type": "double",
+        "doc_values": true
+      },
+
+      "verbrauch_pro_monat": {
+        "type": "double",
+        "doc_values": true
+      },
+
+      "co2_faktor_kg_pro_einheit": {
+        "type": "double"
+      },
+
+      "co2_gesamt_kg": {
+        "type": "double",
+        "doc_values": true
+      },
+
+      "co2_pro_tag_kg": {
+        "type": "double",
+        "doc_values": true
+      },
+
+      "korrektur": {
+        "type": "boolean"
+      },
+
+      "erfasst_von": {
+        "type": "keyword"
+      },
+
+      "erfasst_von_email": {
+        "type": "keyword"
+      },
+
+      "anmerkungen": {
+        "type": "text",
+        "analyzer": "german"
+      },
+
+      "formular_submission_id": {
+        "type": "keyword"
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
@
## Was wurde geändert

Neues Verzeichnis `elasticsearch/` mit Index-Definitionen für das neue Umweltmanagement-Formular **Verbrauchsdaten** (Strom, Wasser, Gas, Heizöl, Diesel, Benzin):

- **`verbrauchsdaten_mapping.json`** – Index-Mapping inkl. `ressource`, `lieferant` (Versorger), `einheit`, Abrechnungsintervall, CO₂-Faktor/-Äquivalent sowie der normalisierten Verbrauchsfelder pro Tag / Woche / Monat.
- **`verbrauchsdaten_aggregations.json`** – Beispiel-Aggregationen, u.a. ein `date_histogram` mit konfigurierbarem `calendar_interval` für die Verarbeitung pro Tag und freie Intervall-Darstellung in Kibana.

## Warum

Grundlage für die Erfassung und Auswertung der Verbrauchsdaten im Umweltmanagement. Der CO₂-Faktor ist pro Datensatz hinterlegt, sodass z.B. ein Stromanbieter-Wechsel korrekt abgebildet wird.

## Hinweis für Reviewer

Die zugehörigen Formular-Dateien unter `forms/` (`Verbrauchsdaten.php`, `IT/Neuer Mitarbeiter.php`) sind bewusst per `.gitignore` (`/forms/*`) ausgeschlossen und daher **nicht** Teil dieses PRs. Die in dieser Session vorgenommenen Formularänderungen (Lieferant-Feld, Trennung Benutzer/neuer Mitarbeiter beim Neuer-Mitarbeiter-Formular) liegen lokal vor, werden aber nicht versioniert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@